### PR TITLE
[jagoda:fix-redirect] Clear cookie header on redirect

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -103,7 +103,7 @@ class Pipeline extends Array {
     assert(handler.length === 2 || handler.length === 3, 'Handler function takes 2 (request handler) or 3 (response handler) arguments');
     this._default.push(handler);
   }
-  
+
   // Remove a request or response handler.
   static removeHandler(handler) {
     assert(handler.call, 'Handler must be a function');
@@ -273,6 +273,9 @@ class Pipeline extends Array {
         request.headers.delete('Content-Transfer-Encoding');
       }
 
+      // The Cookie header will be recomputed when the pipeline runs. This
+      // ensures that cookies can be invalidated by the redirect response.
+      request.headers.delete('Cookie');
       // This request is referer for next
       request.headers.set('Referer', request.url);
       request.url = Utils.resolveHref(request.url, location);

--- a/test/cookies_test.js
+++ b/test/cookies_test.js
@@ -320,6 +320,33 @@ describe('Cookies', function() {
   });
 
 
+  describe('invalidate cookies and redirect', function() {
+    let cookies = {};
+
+    before(function() {
+      brains.get('/cookies/invalidate', function(req, res) {
+        res.clearCookie('_delete');
+        res.redirect('/cookies/invalidated');
+      });
+
+      brains.get('/cookies/invalidated', function(req, res) {
+        Object.assign(cookies, req.cookies);
+        res.send();
+      });
+
+      // Need to ensure that there are no cookies from other tests
+      browser.deleteCookies();
+      browser.setCookie({ name: '_delete', domain: 'example.com', path: '/', value: 'test' });
+      return browser.visit('/cookies/invalidate');
+    });
+
+    it('should unset cookie before redirecting', function() {
+      assert.strictEqual(cookies.hasOwnProperty('_delete'), false);
+      assert.strictEqual(browser.getCookie('_delete'), null);
+    });
+  });
+
+
   describe('duplicates', function() {
 
     before(async function() {


### PR DESCRIPTION
(Per jagoda:fix-redirect) In the event that a redirect invalidates the last cookie, the
cookie store is cleared but the cookie header from the previous
request remains. Since the request pipeline recomputes the cookie
header for each request, this problem can be addressed by
removing the cookie header from the request prior to redirecting.
